### PR TITLE
다른 feature 모듈에서 불필요한 Main Module 의존성 제거

### DIFF
--- a/feature/daily/build.gradle.kts
+++ b/feature/daily/build.gradle.kts
@@ -10,6 +10,5 @@ dependencies {
 
     implementation(project(":domain"))
     implementation(project(":feature:common"))
-    implementation(project(":feature:main"))
-    implementation(project( ":feature:category"))
+    implementation(project(":feature:category"))
 }

--- a/feature/daily/src/main/java/com/hegunhee/daily/DailyFragment.kt
+++ b/feature/daily/src/main/java/com/hegunhee/daily/DailyFragment.kt
@@ -2,10 +2,10 @@ package com.hegunhee.daily
 
 import android.os.Bundle
 import android.view.View
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.hegunhee.common.base.BaseFragment
-import com.example.main.MainActivity
 import com.hegunhee.daily.databinding.FragmentDailyBinding
 import com.hegunhee.daily.insert.InsertRoutineDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -28,7 +28,7 @@ class DailyFragment : BaseFragment<FragmentDailyBinding>(R.layout.fragment_daily
     }
 
     private fun setActionBarTitle(){
-        (requireActivity() as MainActivity).supportActionBar?.title = "오늘의 루틴"
+        (requireActivity() as AppCompatActivity).supportActionBar?.title = "오늘의 루틴"
     }
 
     private fun initObserver(){

--- a/feature/record/build.gradle.kts
+++ b/feature/record/build.gradle.kts
@@ -10,5 +10,4 @@ dependencies {
 
     implementation(project(":domain"))
     implementation(project(":feature:common"))
-    implementation(project(":feature:main"))
 }

--- a/feature/record/src/main/java/com/hegunhee/record/RecordFragment.kt
+++ b/feature/record/src/main/java/com/hegunhee/record/RecordFragment.kt
@@ -6,10 +6,10 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.hegunhee.common.base.BaseFragment
-import com.example.main.MainActivity
 import com.hegunhee.record.databinding.FragmentRecordBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -45,7 +45,7 @@ class RecordFragment : BaseFragment<FragmentRecordBinding>(R.layout.fragment_rec
     }
 
     private fun setActionBarTitle(title : String){
-        (requireActivity() as MainActivity).supportActionBar?.title = title
+        (requireActivity() as AppCompatActivity).supportActionBar?.title = title
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {

--- a/feature/repeat/build.gradle.kts
+++ b/feature/repeat/build.gradle.kts
@@ -10,6 +10,5 @@ dependencies {
 
     implementation(project(":domain"))
     implementation(project(":feature:common"))
-    implementation(project(":feature:main"))
     implementation(project(":feature:category"))
 }

--- a/feature/repeat/src/main/java/com/hegunhee/repeat/RepeatFragment.kt
+++ b/feature/repeat/src/main/java/com/hegunhee/repeat/RepeatFragment.kt
@@ -3,6 +3,7 @@ package com.hegunhee.repeat
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.example.domain.model.RepeatRoutine
@@ -28,10 +29,13 @@ class RepeatFragment : BaseFragment<FragmentRepeatBinding>(R.layout.fragment_rep
             viewmodel = viewModel
             recyclerView.adapter = adapter
         }
-        (requireActivity() as MainActivity).supportActionBar?.title = "반복 루틴 설정"
+        setActionBarTitle()
         initObserver()
         observeData()
+    }
 
+    private fun setActionBarTitle(){
+        (requireActivity() as AppCompatActivity).supportActionBar?.title = "반복 루틴 설정"
     }
 
     private fun initObserver() {

--- a/feature/repeat/src/main/java/com/hegunhee/repeat/RepeatFragment.kt
+++ b/feature/repeat/src/main/java/com/hegunhee/repeat/RepeatFragment.kt
@@ -8,7 +8,6 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.example.domain.model.RepeatRoutine
 import com.hegunhee.common.base.BaseFragment
-import com.example.main.MainActivity
 import com.hegunhee.repeat.databinding.DialogClickRepeatRecordItemBinding
 import com.hegunhee.repeat.databinding.FragmentRepeatBinding
 import com.hegunhee.repeat.insert.InsertRepeatRoutineDialogFragment

--- a/feature/setting/build.gradle.kts
+++ b/feature/setting/build.gradle.kts
@@ -10,5 +10,4 @@ dependencies {
 
     implementation(project(":domain"))
     implementation(project(":feature:common"))
-    implementation(project(":feature:main"))
 }

--- a/feature/setting/src/main/java/com/hegunhee/setting/SettingFragment.kt
+++ b/feature/setting/src/main/java/com/hegunhee/setting/SettingFragment.kt
@@ -6,7 +6,6 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.viewModels
 import com.hegunhee.common.base.BaseFragment
-import com.example.main.MainActivity
 import com.hegunhee.setting.databinding.FragmentSettingBinding
 import dagger.hilt.android.AndroidEntryPoint
 

--- a/feature/setting/src/main/java/com/hegunhee/setting/SettingFragment.kt
+++ b/feature/setting/src/main/java/com/hegunhee/setting/SettingFragment.kt
@@ -3,6 +3,7 @@ package com.hegunhee.setting
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.viewModels
 import com.hegunhee.common.base.BaseFragment
 import com.example.main.MainActivity
@@ -16,14 +17,19 @@ class SettingFragment : BaseFragment<FragmentSettingBinding>(R.layout.fragment_s
     private val viewModel : SettingViewModel by viewModels()
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        (requireActivity() as MainActivity).supportActionBar?.title = "설정"
         binding.apply {
             viewmodel = viewModel
             notiSwitchButton.isChecked = viewModel.getNotiSendValue()
         }
+        setActionBarTitle()
         initListener()
-
     }
+
+    private fun setActionBarTitle(){
+        (requireActivity() as AppCompatActivity).supportActionBar?.title = "설정"
+    }
+
+
     private fun initListener() = with(binding){
         notiSwitchButton.setOnCheckedChangeListener { _, switch ->
             viewModel.setNotiSendValue(switch)


### PR DESCRIPTION
AS-IS
현재 ActionBar Title을 설정해야하는 Fragment에서
ActionBar Title을 설정해야해서 MainActivity를 참조하는 현상이 발견됨
MainActivity를 참조해야 하기때문에 feature:main 모듈을 의존하고 있음
TO-BE
AppCompatActivity만 알면 되기때문에
Main모듈에 대한 의존성을 지울 수 있음