### PR TITLE
guideDialog를 하나의 Fragment로 분리

### DIFF
--- a/feature/common/src/main/java/com/hegunhee/common/base/BaseDialog.kt
+++ b/feature/common/src/main/java/com/hegunhee/common/base/BaseDialog.kt
@@ -13,7 +13,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.DialogFragment
 
-abstract class BaseDialog<T : ViewDataBinding>(@LayoutRes private val layoutResId : Int,val widthPercent : Double,val heightPercent : Double) : DialogFragment() {
+abstract class BaseDialog<T : ViewDataBinding>(@LayoutRes private val layoutResId : Int,val widthPercent : Double = WIDTH_PERCENT,val heightPercent : Double = HEIGHT_PERCENT) : DialogFragment() {
 
     private var _binding: T? = null
     val binding get() = _binding ?: error("View를 참조하기 위해 binding이 초기화 되지 않았습니다.")

--- a/feature/common/src/main/java/com/hegunhee/common/base/BaseDialog.kt
+++ b/feature/common/src/main/java/com/hegunhee/common/base/BaseDialog.kt
@@ -13,7 +13,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.DialogFragment
 
-abstract class BaseDialog<T : ViewDataBinding>(@LayoutRes private val layoutResId : Int,val widthPercent : Double = WIDTH_PERCENT,val heightPercent : Double = HEIGHT_PERCENT) : DialogFragment() {
+abstract class BaseDialog<T : ViewDataBinding>(@LayoutRes private val layoutResId : Int,val widthPercent : Double,val heightPercent : Double) : DialogFragment() {
 
     private var _binding: T? = null
     val binding get() = _binding ?: error("View를 참조하기 위해 binding이 초기화 되지 않았습니다.")

--- a/feature/main/src/main/java/com/example/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/example/main/MainActivity.kt
@@ -7,14 +7,11 @@ import android.view.MenuItem
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 import com.example.main.databinding.ActivityMainBinding
-import com.example.main.databinding.DialogFirstOpenBinding
 import com.example.main.databinding.DialogGuideBinding
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {

--- a/feature/main/src/main/java/com/example/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/example/main/MainActivity.kt
@@ -4,13 +4,10 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.Gravity
 import android.view.MenuItem
-import android.widget.Toast
 import androidx.activity.viewModels
-import androidx.appcompat.app.AlertDialog
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 import com.example.main.databinding.ActivityMainBinding
-import com.example.main.databinding.DialogGuideBinding
 import com.example.main.guide.GuideDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -48,17 +45,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun openGuideDialog() {
-        val guideDialogFragment = GuideDialogFragment.getInstance()
-        guideDialogFragment.show(supportFragmentManager,GuideDialogFragment.TAG)
-//        val customDialogBinding = DialogGuideBinding.inflate(layoutInflater)
-//        val dialog = AlertDialog.Builder(this).setView(customDialogBinding.root).show()
-//        dialog.setCancelable(false)
-//        customDialogBinding.alertAcceptButton.setOnClickListener {
-//            val isChecked = customDialogBinding.alertSwitch.isChecked
-//            viewModel.setAppFirstOpened()
-//            Toast.makeText(this@MainActivity, getString(R.string.notification_setting,if(isChecked) "승인" else "해제"), Toast.LENGTH_SHORT).show()
-//            dialog.dismiss()
-//        }
+        GuideDialogFragment.getInstance().show(supportFragmentManager,GuideDialogFragment.TAG)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/feature/main/src/main/java/com/example/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/example/main/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 import com.example.main.databinding.ActivityMainBinding
 import com.example.main.databinding.DialogGuideBinding
+import com.example.main.guide.GuideDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -47,15 +48,17 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun openGuideDialog() {
-        val customDialogBinding = DialogGuideBinding.inflate(layoutInflater)
-        val dialog = AlertDialog.Builder(this).setView(customDialogBinding.root).show()
-        dialog.setCancelable(false)
-        customDialogBinding.alertAcceptButton.setOnClickListener {
-            val isChecked = customDialogBinding.alertSwitch.isChecked
-            viewModel.setAppFirstOpened()
-            Toast.makeText(this@MainActivity, getString(R.string.notification_setting,if(isChecked) "승인" else "해제"), Toast.LENGTH_SHORT).show()
-            dialog.dismiss()
-        }
+        val guideDialogFragment = GuideDialogFragment.getInstance()
+        guideDialogFragment.show(supportFragmentManager,GuideDialogFragment.TAG)
+//        val customDialogBinding = DialogGuideBinding.inflate(layoutInflater)
+//        val dialog = AlertDialog.Builder(this).setView(customDialogBinding.root).show()
+//        dialog.setCancelable(false)
+//        customDialogBinding.alertAcceptButton.setOnClickListener {
+//            val isChecked = customDialogBinding.alertSwitch.isChecked
+//            viewModel.setAppFirstOpened()
+//            Toast.makeText(this@MainActivity, getString(R.string.notification_setting,if(isChecked) "승인" else "해제"), Toast.LENGTH_SHORT).show()
+//            dialog.dismiss()
+//        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/feature/main/src/main/java/com/example/main/MainViewModel.kt
+++ b/feature/main/src/main/java/com/example/main/MainViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.viewModelScope
 import com.example.domain.usecase.date.*
 import com.example.domain.usecase.routine.GetRoutineListByDateUseCase
 import com.example.domain.usecase.routine.InsertAllDailyRoutineFromRepeatRoutineUseCase
-import com.example.domain.usecase.notification.SetNotiSendValueUseCase
 import com.hegunhee.common.util.getTodayDate
 import com.hegunhee.common.util.getTodayDayOfWeekFormatedKorean
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -20,12 +19,10 @@ import javax.inject.Inject
 class MainViewModel @Inject constructor(
     private val getCurrentDateUseCase: GetCurrentDateUseCase,
     private val setCurrentDateUseCase: SetCurrentDateUseCase,
-    private val setNotiSendValueUseCase: SetNotiSendValueUseCase,
     private val getRoutineListByDateUseCase: GetRoutineListByDateUseCase,
     private val insertDateUseCase: InsertDateUseCase,
     private val insertAllDailyRoutineFromRepeatRoutineUseCase: InsertAllDailyRoutineFromRepeatRoutineUseCase,
     private val isAppFirstOpenUseCase: IsAppFirstOpenUseCase,
-    private val setAppFirstOpenedUseCase: SetAppFirstOpenedUseCase
 ) : ViewModel() {
 
     init {
@@ -48,12 +45,4 @@ class MainViewModel @Inject constructor(
     fun isAppFirstOpen() : Boolean {
         return isAppFirstOpenUseCase()
     }
-
-    fun setAppFirstOpened(){
-        setAppFirstOpenedUseCase()
-    }
-
-
-
-
 }

--- a/feature/main/src/main/java/com/example/main/guide/GuideDialogFragment.kt
+++ b/feature/main/src/main/java/com/example/main/guide/GuideDialogFragment.kt
@@ -1,9 +1,7 @@
 package com.example.main.guide
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope

--- a/feature/main/src/main/java/com/example/main/guide/GuideDialogFragment.kt
+++ b/feature/main/src/main/java/com/example/main/guide/GuideDialogFragment.kt
@@ -1,7 +1,10 @@
 package com.example.main.guide
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
 import com.example.main.R
 import com.example.main.databinding.DialogGuideBinding
 import com.hegunhee.common.base.BaseDialog
@@ -10,11 +13,14 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class GuideDialogFragment() : BaseDialog<DialogGuideBinding>(layoutResId = R.layout.dialog_guide,widthPercent = 0.8,heightPercent = 0.4) {
 
+    private val viewModel : GuideViewModel by viewModels()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.alertAcceptButton.setOnClickListener {
-            dismissAllowingStateLoss()
-        }
+        binding.viewModel = viewModel
+//        binding.alertAcceptButton.setOnClickListener {
+//            dismissAllowingStateLoss()
+//        }
     }
 
 

--- a/feature/main/src/main/java/com/example/main/guide/GuideDialogFragment.kt
+++ b/feature/main/src/main/java/com/example/main/guide/GuideDialogFragment.kt
@@ -1,11 +1,30 @@
 package com.example.main.guide
 
+import android.os.Bundle
+import android.view.View
 import com.example.main.R
 import com.example.main.databinding.DialogGuideBinding
 import com.hegunhee.common.base.BaseDialog
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class GuideDialogFragment : BaseDialog<DialogGuideBinding>(layoutResId = R.layout.dialog_guide) {
+class GuideDialogFragment() : BaseDialog<DialogGuideBinding>(layoutResId = R.layout.dialog_guide,widthPercent = 0.8,heightPercent = 0.4) {
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.alertAcceptButton.setOnClickListener {
+            dismissAllowingStateLoss()
+        }
+    }
+
+
+
+    companion object{
+        const val TAG = "GuideDialogFragment"
+        fun getInstance() : GuideDialogFragment{
+            return GuideDialogFragment().apply {
+                isCancelable = false
+            }
+        }
+    }
 }

--- a/feature/main/src/main/java/com/example/main/guide/GuideDialogFragment.kt
+++ b/feature/main/src/main/java/com/example/main/guide/GuideDialogFragment.kt
@@ -4,11 +4,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import com.example.main.R
 import com.example.main.databinding.DialogGuideBinding
 import com.hegunhee.common.base.BaseDialog
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class GuideDialogFragment() : BaseDialog<DialogGuideBinding>(layoutResId = R.layout.dialog_guide,widthPercent = 0.8,heightPercent = 0.4) {
@@ -18,11 +21,19 @@ class GuideDialogFragment() : BaseDialog<DialogGuideBinding>(layoutResId = R.lay
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
-//        binding.alertAcceptButton.setOnClickListener {
-//            dismissAllowingStateLoss()
-//        }
+        observeData()
     }
 
+    private fun observeData() {
+        viewLifecycleOwner.lifecycleScope.launchWhenStarted {
+            launch {
+                viewModel.navigateDismissDialog.collect{
+                    Toast.makeText(requireActivity(), getString(R.string.notification_setting,if(viewModel.isAllowNotification.value) "승인" else "해제"), Toast.LENGTH_SHORT).show()
+                    dismissAllowingStateLoss()
+                }
+            }
+        }
+    }
 
 
     companion object{

--- a/feature/main/src/main/java/com/example/main/guide/GuideDialogFragment.kt
+++ b/feature/main/src/main/java/com/example/main/guide/GuideDialogFragment.kt
@@ -1,0 +1,11 @@
+package com.example.main.guide
+
+import com.example.main.R
+import com.example.main.databinding.DialogGuideBinding
+import com.hegunhee.common.base.BaseDialog
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class GuideDialogFragment : BaseDialog<DialogGuideBinding>(layoutResId = R.layout.dialog_guide) {
+
+}

--- a/feature/main/src/main/java/com/example/main/guide/GuideViewModel.kt
+++ b/feature/main/src/main/java/com/example/main/guide/GuideViewModel.kt
@@ -3,6 +3,7 @@ package com.example.main.guide
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.domain.usecase.date.SetAppFirstOpenedUseCase
 import com.example.domain.usecase.notification.SetNotiSendValueUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -14,6 +15,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class GuideViewModel @Inject constructor(
+    private val setAppFirstOpenedUseCase: SetAppFirstOpenedUseCase,
     private val setNotiSendValueUseCase : SetNotiSendValueUseCase
 ): ViewModel() {
 
@@ -25,6 +27,7 @@ class GuideViewModel @Inject constructor(
 
     fun onClickDismissDialogButton() {
         viewModelScope.launch {
+            setAppFirstOpenedUseCase()
             setNotiSendValueUseCase(isAllowNotification.value)
             _navigateDismissDialog.emit(Unit)
         }

--- a/feature/main/src/main/java/com/example/main/guide/GuideViewModel.kt
+++ b/feature/main/src/main/java/com/example/main/guide/GuideViewModel.kt
@@ -1,9 +1,18 @@
 package com.example.main.guide
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
 
 @HiltViewModel
 class GuideViewModel @Inject constructor(): ViewModel() {
+
+    val isAllowNotification : MutableStateFlow<Boolean> = MutableStateFlow<Boolean>(false)
+
+
+    fun onClickDismissDialogButton() {
+        Log.d("TEST!!!",isAllowNotification.value.toString())
+    }
 }

--- a/feature/main/src/main/java/com/example/main/guide/GuideViewModel.kt
+++ b/feature/main/src/main/java/com/example/main/guide/GuideViewModel.kt
@@ -11,6 +11,8 @@ class GuideViewModel @Inject constructor(): ViewModel() {
 
     val isAllowNotification : MutableStateFlow<Boolean> = MutableStateFlow<Boolean>(false)
 
+    private val _navigateDismissDialog : MutableSharedFlow<Unit> = MutableSharedFlow()
+    val navigateDismissDialog : SharedFlow<Unit> = _navigateDismissDialog.asSharedFlow()
 
     fun onClickDismissDialogButton() {
         Log.d("TEST!!!",isAllowNotification.value.toString())

--- a/feature/main/src/main/java/com/example/main/guide/GuideViewModel.kt
+++ b/feature/main/src/main/java/com/example/main/guide/GuideViewModel.kt
@@ -1,6 +1,5 @@
 package com.example.main.guide
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.domain.usecase.date.SetAppFirstOpenedUseCase

--- a/feature/main/src/main/java/com/example/main/guide/GuideViewModel.kt
+++ b/feature/main/src/main/java/com/example/main/guide/GuideViewModel.kt
@@ -1,0 +1,9 @@
+package com.example.main.guide
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class GuideViewModel @Inject constructor(): ViewModel() {
+}

--- a/feature/main/src/main/java/com/example/main/guide/GuideViewModel.kt
+++ b/feature/main/src/main/java/com/example/main/guide/GuideViewModel.kt
@@ -2,19 +2,31 @@ package com.example.main.guide
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.domain.usecase.notification.SetNotiSendValueUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class GuideViewModel @Inject constructor(): ViewModel() {
+class GuideViewModel @Inject constructor(
+    private val setNotiSendValueUseCase : SetNotiSendValueUseCase
+): ViewModel() {
 
     val isAllowNotification : MutableStateFlow<Boolean> = MutableStateFlow<Boolean>(false)
 
     private val _navigateDismissDialog : MutableSharedFlow<Unit> = MutableSharedFlow()
     val navigateDismissDialog : SharedFlow<Unit> = _navigateDismissDialog.asSharedFlow()
 
+
     fun onClickDismissDialogButton() {
-        Log.d("TEST!!!",isAllowNotification.value.toString())
+        viewModelScope.launch {
+            setNotiSendValueUseCase(isAllowNotification.value)
+            _navigateDismissDialog.emit(Unit)
+        }
     }
 }

--- a/feature/main/src/main/res/layout/dialog_guide.xml
+++ b/feature/main/src/main/res/layout/dialog_guide.xml
@@ -2,7 +2,12 @@
 
 <layout>
 
+    <data>
 
+        <variable
+            name="viewModel"
+            type="com.example.main.guide.GuideViewModel" />
+    </data>
     <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"

--- a/feature/main/src/main/res/layout/dialog_guide.xml
+++ b/feature/main/src/main/res/layout/dialog_guide.xml
@@ -40,6 +40,7 @@
             app:layout_constraintBottom_toTopOf="@id/alert_accept_button"
             app:layout_constraintStart_toStartOf="@id/alert_title"
             app:layout_constraintTop_toBottomOf="@id/alert_title"
+            android:checked="@={viewModel.isAllowNotification}"
             app:layout_constraintVertical_chainStyle="packed" />
 
 
@@ -67,6 +68,7 @@
             app:layout_constraintEnd_toEndOf="@id/alert_title"
             app:layout_constraintStart_toStartOf="@id/alert_title"
             app:layout_constraintTop_toBottomOf="@id/alert_switch"
-            app:layout_constraintVertical_chainStyle="packed" />
+            app:layout_constraintVertical_chainStyle="packed"
+            android:onClick="@{() -> viewModel.onClickDismissDialogButton()}"/>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/feature/main/src/main/res/layout/dialog_guide.xml
+++ b/feature/main/src/main/res/layout/dialog_guide.xml
@@ -3,69 +3,65 @@
 <layout>
 
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:background="@color/white"
-    android:layout_height="match_parent">
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/white">
 
 
-    <TextView
-        android:layout_marginTop="20dp"
-        android:id="@+id/alert_title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:text="저희 앱을 사용해주셔서 감사합니다."
-        android:textColor="@color/black"
-        android:textSize="20dp"
-        android:textStyle="bold"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/alert_switch"
-        app:layout_constraintVertical_chainStyle="packed"
-        />
+        <TextView
+            android:id="@+id/alert_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:gravity="center"
+            android:text="저희 앱을 사용해주셔서 감사합니다."
+            android:textColor="@color/black"
+            android:textSize="20dp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toTopOf="@id/alert_switch"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed" />
 
 
-    <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/alert_switch"
-        android:background="@color/white"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/alert_title"
-        app:layout_constraintStart_toStartOf="@id/alert_title"
-        app:layout_constraintBottom_toTopOf="@id/alert_accept_button"
-        app:layout_constraintVertical_chainStyle="packed"
-        />
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/alert_switch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@color/white"
+            app:layout_constraintBottom_toTopOf="@id/alert_accept_button"
+            app:layout_constraintStart_toStartOf="@id/alert_title"
+            app:layout_constraintTop_toBottomOf="@id/alert_title"
+            app:layout_constraintVertical_chainStyle="packed" />
 
 
-    <TextView
-        android:id="@+id/alert_desc"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="(선택) 알람 수신을 받겠습니다."
-        android:textColor="@color/black"
-        android:textSize="15dp"
-        android:background="@color/white"
-        app:layout_constraintEnd_toEndOf="@id/alert_title"
-        app:layout_constraintTop_toTopOf="@id/alert_switch"
-        app:layout_constraintBottom_toBottomOf="@id/alert_switch"
-        />
+        <TextView
+            android:id="@+id/alert_desc"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@color/white"
+            android:text="(선택) 알람 수신을 받겠습니다."
+            android:textColor="@color/black"
+            android:textSize="15dp"
+            app:layout_constraintBottom_toBottomOf="@id/alert_switch"
+            app:layout_constraintEnd_toEndOf="@id/alert_title"
+            app:layout_constraintTop_toTopOf="@id/alert_switch" />
 
 
-    <Button
-        android:id="@+id/alert_accept_button"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="@id/alert_title"
-        app:layout_constraintEnd_toEndOf="@id/alert_title"
-        app:layout_constraintTop_toBottomOf="@id/alert_switch"
-        android:text="수락"
-        android:backgroundTint="@color/black"
-        android:layout_marginBottom="20dp"
-        app:layout_constraintVertical_chainStyle="packed"
-        app:layout_constraintBottom_toBottomOf="parent"
-        />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <Button
+            android:id="@+id/alert_accept_button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="20dp"
+            android:backgroundTint="@color/black"
+            android:text="수락"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/alert_title"
+            app:layout_constraintStart_toStartOf="@id/alert_title"
+            app:layout_constraintTop_toBottomOf="@id/alert_switch"
+            app:layout_constraintVertical_chainStyle="packed" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
AS-IS
guideDialog를 Dialog 생성하는 방식으로 사용했음
해당 Dialog 관련 코드를 MainActivity에서 가지고있고
사용하는 UseCase를 MainViewModel에서 가지고있어야 하기 때문에
MainActivity와 MainViewModel이 커짐
TO-BE
하나의 패키지로 분리해 확장이 용이하고
MainActivity가 가벼워짐