### PR TITLE
SharedPreference 테스트코드 작성

### DIFF
--- a/core/data/src/androidTest/java/com/example/data/sharedpreference/SharedPreferenceManagerTest.kt
+++ b/core/data/src/androidTest/java/com/example/data/sharedpreference/SharedPreferenceManagerTest.kt
@@ -1,0 +1,45 @@
+package com.example.data.sharedpreference
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.example.data.db.SharedPreferenceManager
+import org.junit.After
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.runner.RunWith
+
+
+@RunWith(AndroidJUnit4::class)
+class SharedPreferenceManagerTest {
+
+    private lateinit var sut: SharedPreferenceManager
+
+    private lateinit var sharedPreference: SharedPreferences
+
+    companion object {
+        @BeforeClass
+        @JvmStatic
+        fun initPrefsName() {
+            val companionObject = SharedPreferenceManager::class.java.getDeclaredField("PRES_NAME")
+            companionObject.isAccessible = true
+            companionObject.set(null, "test_prefs")
+        }
+    }
+
+
+    @Before
+    fun initPrefs() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        sut = SharedPreferenceManager(context)
+        sharedPreference = context.getSharedPreferences(SharedPreferenceManager.PRES_NAME, Context.MODE_PRIVATE)
+        sharedPreference.edit().clear().apply()
+    }
+
+    @After
+    fun tearDown() {
+        sharedPreference.edit().clear().apply()
+    }
+
+}

--- a/core/data/src/androidTest/java/com/example/data/sharedpreference/SharedPreferenceManagerTest.kt
+++ b/core/data/src/androidTest/java/com/example/data/sharedpreference/SharedPreferenceManagerTest.kt
@@ -6,8 +6,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.example.data.db.SharedPreferenceManager
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.BeforeClass
+import org.junit.Test
 import org.junit.runner.RunWith
 
 
@@ -33,13 +37,86 @@ class SharedPreferenceManagerTest {
     fun initPrefs() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         sut = SharedPreferenceManager(context)
-        sharedPreference = context.getSharedPreferences(SharedPreferenceManager.PRES_NAME, Context.MODE_PRIVATE)
+        sharedPreference =
+            context.getSharedPreferences(SharedPreferenceManager.PRES_NAME, Context.MODE_PRIVATE)
         sharedPreference.edit().clear().apply()
     }
 
     @After
     fun tearDown() {
         sharedPreference.edit().clear().apply()
+    }
+
+    @Test
+    fun given_whenGetCurrentDate_thenReturnsDefaultDate() {
+        // given
+
+        // when
+        val currentDate = sut.getCurrentDate()
+
+        // then
+        assertEquals(currentDate, SharedPreferenceManager.CURRENT_DATE_DEFAULT_DATE)
+    }
+
+    @Test
+    fun givenDate_whenSetCurrentDate_thenReturnsSetDate() {
+        // given
+        val date = 20250226
+
+        // when
+        sut.setCurrentDate(date)
+        val setDate = sut.getCurrentDate()
+
+        // then
+        assertEquals(setDate, date)
+
+    }
+
+    @Test
+    fun given_whenGetAlarmNotiTime_thenReturnsDefaultTime() {
+        // given
+
+        // when
+        val alarmNotiTime = sut.getAlarmNotiTime()
+
+        // then
+        assertEquals(alarmNotiTime, SharedPreferenceManager.ALARM_NOTI_DEFAULT)
+    }
+
+    @Test
+    fun givenAlarmNotiTime_whenSetAlarmNotiTime_thenReturnsSetTime() {
+        // given
+        val notiTime = "02:30"
+
+        // when
+        sut.setAlarmNotiTime(notiTime)
+        val setNotiTime = sut.getAlarmNotiTime()
+
+        // then
+        assertEquals(setNotiTime, notiTime)
+    }
+
+    @Test
+    fun given_whenGetIsAppFirstOpen_thenDefaultBoolean() {
+        // given
+
+        // when
+        val isAppFirstOpened = sut.isAppFirstOpened()
+
+        // then
+        assertTrue(isAppFirstOpened)
+    }
+
+    @Test
+    fun given_whenSetIsAppFirstTime_thenReturnsFalse() {
+        // given
+
+        // when
+        sut.setAppFirstOpened()
+        val isAppFirstOpened = sut.isAppFirstOpened()
+
+        // then
+        assertFalse(isAppFirstOpened)
     }
 
 }

--- a/core/data/src/main/java/com/example/data/db/SharedPreferenceManager.kt
+++ b/core/data/src/main/java/com/example/data/db/SharedPreferenceManager.kt
@@ -35,7 +35,7 @@ class SharedPreferenceManager @Inject constructor(@ApplicationContext private va
 
 
     companion object{
-        const val PRES_NAME = "routiner_pref"
+        val PRES_NAME = "routiner_pref"
 
         const val CURRENT_DATE_KEY = "currentDate"
         const val CURRENT_DATE_DEFAULT_DATE = -1


### PR DESCRIPTION
리팩터링이 이뤄지기 전 SharedPreference 테스트를 작성했다.

해당 이슈는 #62 에 병합된다.

mock이 아닌 SharedPreferenceManager를 직접 사용하고싶어서 
경로가 다른 SharedPreference를 사용했고
테스트의 시작과 끝에 롤백된다.

This closes #65 