### PR TITLE
PK로 엔티티 조회, 삭제, 추가시 PK 반환하도록 DB 설정

### DIFF
--- a/core/data/src/androidTest/java/com/example/data/db/dao/CategoryDaoTest.kt
+++ b/core/data/src/androidTest/java/com/example/data/db/dao/CategoryDaoTest.kt
@@ -39,7 +39,7 @@ class CategoryDaoTest {
 
             // when
             sut.insertCategory(entity)
-            val insertedEntity = sut.getAllCategoryListByFlow().first()[0]
+            val insertedEntity = sut.getCategoriesFlow().first()[0]
 
             // then
             assertEquals(insertedEntity, entity)
@@ -51,13 +51,13 @@ class CategoryDaoTest {
         runBlocking {
             // given
             val entity = CategoryEntity("운동")
-            val previousCount = sut.getAllCategoryListByFlow().first().size
+            val previousCount = sut.getCategoriesFlow().first().size
 
             // when
             sut.insertCategory(entity)
             sut.insertCategory(entity)
             val entities =
-                sut.getAllCategoryListByFlow().first().filter { it.name == entity.name }
+                sut.getCategoriesFlow().first().filter { it.name == entity.name }
 
             // then
             assertEquals(entities.size, previousCount + 1)
@@ -70,14 +70,12 @@ class CategoryDaoTest {
             // given
             val entity = CategoryEntity("운동")
             sut.insertCategory(entity)
-            val previousCount = sut.getAllCategoryListByFlow().first().size
 
             // when
-            sut.removeCategory(entity)
-            val count = sut.getAllCategoryListByFlow().first().size
+            val deleteCategoryCount = sut.deleteCategory(entity)
 
             // then
-            assertEquals(count, previousCount - 1)
+            assertEquals(deleteCategoryCount, 1)
         }
     }
 
@@ -89,15 +87,15 @@ class CategoryDaoTest {
             previousEntities.forEach {
                 sut.insertCategory(it)
             }
-            val entitiesFlow = sut.getAllCategoryListByFlow()
+            val entitiesFlow = sut.getCategoriesFlow()
 
             // when
-            sut.removeCategory(previousEntities[0])
+            sut.deleteCategory(previousEntities[0])
             val entities = entitiesFlow.first()
 
             // then
             assertEquals(entities.size, previousEntities.size - 1)
-            assertEquals(entities[0],previousEntities.first { it.name == entities[0].name })
+            assertEquals(entities[0], previousEntities.first { it.name == entities[0].name })
         }
     }
 }

--- a/core/data/src/androidTest/java/com/example/data/db/dao/DateDaoTest.kt
+++ b/core/data/src/androidTest/java/com/example/data/db/dao/DateDaoTest.kt
@@ -35,11 +35,11 @@ class DateDaoTest {
         runBlocking {
             // given
             val entity = DateEntity(20250227)
-            val previousEntities = sut.getAllDateList()
+            val previousEntities = sut.getDateList()
 
             // when
             sut.insertDate(entity)
-            val entities = sut.getAllDateList()
+            val entities = sut.getDateList()
 
             // then
             assertEquals(entities.size, previousEntities.size + 1)

--- a/core/data/src/androidTest/java/com/example/data/db/dao/RepeatRoutineDaoTest.kt
+++ b/core/data/src/androidTest/java/com/example/data/db/dao/RepeatRoutineDaoTest.kt
@@ -35,11 +35,11 @@ class RepeatRoutineDaoTest {
         runBlocking {
             // given
             val entity = createRepeatRoutineEntity("가슴운동")
-            val previousCount = sut.getAllRepeatRoutineList().size
+            val previousCount = sut.getRepeatRoutines().size
 
             // when
             sut.insertRepeatRoutine(entity)
-            val count = sut.getAllRepeatRoutineList().size
+            val count = sut.getRepeatRoutines().size
 
             // then
             assertEquals(count, previousCount + 1)
@@ -52,12 +52,12 @@ class RepeatRoutineDaoTest {
             // given
             val text = "가슴 운동"
             val changedCategory = "진짜 운동"
-            val entity = createRepeatRoutineEntity(text,"운동")
+            val entity = createRepeatRoutineEntity(text, "운동")
             sut.insertRepeatRoutine(entity)
 
             // when
             sut.insertRepeatRoutine(entity.copy(category = changedCategory))
-            val entities = sut.getAllRepeatRoutineList()
+            val entities = sut.getRepeatRoutines()
 
             // then
             assertEquals(entities.first { it.text == text }.category, changedCategory)
@@ -71,14 +71,12 @@ class RepeatRoutineDaoTest {
             val text = "가슴 운동"
             val entity = createRepeatRoutineEntity(text)
             sut.insertRepeatRoutine(entity)
-            val previousCount = sut.getAllRepeatRoutineList().size
 
             // when
-            sut.deleteRepeatRoutine(text)
-            val count = sut.getAllRepeatRoutineList().size
+            val deleteRepeatRoutineCount = sut.deleteRepeatRoutine(text)
 
             // then
-            assertEquals(count,previousCount - 1)
+            assertEquals(deleteRepeatRoutineCount, 1)
         }
     }
 

--- a/core/data/src/androidTest/java/com/example/data/db/dao/ReviewDaoTest.kt
+++ b/core/data/src/androidTest/java/com/example/data/db/dao/ReviewDaoTest.kt
@@ -43,7 +43,7 @@ class ReviewDaoTest {
             val insertingEntity = sut.getReviewOrNullByDate(date)
 
             // then
-            assertEquals(insertingEntity,entity)
+            assertEquals(insertingEntity, entity)
         }
     }
 
@@ -66,15 +66,14 @@ class ReviewDaoTest {
         runBlocking {
             // given
             val date = 20250227
-            val entity = createReviewEntity(date,"")
+            val entity = createReviewEntity(date, "")
             sut.insertReview(entity)
 
             // when
-            sut.deleteReview(entity)
-            val deletedEntity = sut.getReviewOrNullByDate(date)
+            val deleteCount = sut.deleteReview(entity)
 
             // then
-            assertNull(deletedEntity)
+            assertEquals(deleteCount, 1)
         }
     }
 

--- a/core/data/src/androidTest/java/com/example/data/db/dao/RoutineDaoTest.kt
+++ b/core/data/src/androidTest/java/com/example/data/db/dao/RoutineDaoTest.kt
@@ -7,8 +7,8 @@ import com.example.data.db.RoutinerDatabase
 import com.example.data.entity.RoutineEntity
 import kotlinx.coroutines.runBlocking
 import org.junit.After
-import org.junit.Assert
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThat
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -39,11 +39,11 @@ class RoutineDaoTest {
             val date = 20250227
             val text = "text"
             val entity = createRoutineEntity(date, text)
-            val previousCount = sut.getRoutineListByDate(date).size
+            val previousCount = sut.getRoutinesByDate(date).size
 
             // when
             sut.insertRoutine(entity)
-            val insertingEntities = sut.getRoutineListByDate(date)
+            val insertingEntities = sut.getRoutinesByDate(date)
 
             // then
             assertEquals(insertingEntities.size, previousCount + 1)
@@ -58,14 +58,12 @@ class RoutineDaoTest {
             val date = 20250227
             val size = 5
             val entities = createRoutineEntitiesWith(size, date)
-            val previousCount = sut.getRoutineListByDate(date).size
 
             // when
-            sut.insertAllRoutine(entities)
-            val insertingEntities = sut.getRoutineListByDate(date)
+            val insertRoutinesRowIds = sut.insertRoutines(entities)
 
             // then
-            assertEquals(insertingEntities.size, previousCount + size)
+            assertEquals(insertRoutinesRowIds.size, size)
         }
     }
 
@@ -78,13 +76,12 @@ class RoutineDaoTest {
             val date2 = 20250225
             val size2 = 3
 
-            val entities =
-                createRoutineEntitiesWith(size1, date1) + createRoutineEntitiesWith(size2, date2)
+            val entities = createRoutineEntitiesWith(size1, date1) + createRoutineEntitiesWith(size2, date2)
 
-            sut.insertAllRoutine(entities)
+            sut.insertRoutines(entities)
 
             // when
-            val entitiesByDate = sut.getRoutineListByDate(date1)
+            val entitiesByDate = sut.getRoutinesByDate(date1)
 
             // then
             assertEquals(entitiesByDate.size, size1)
@@ -100,11 +97,11 @@ class RoutineDaoTest {
             val text = "asdsd"
             val entity = createRoutineEntity(date, text)
             sut.insertRoutine(entity)
-            val previousEntities = sut.getRoutineListByDate(date)
+            val previousEntities = sut.getRoutinesByDate(date)
 
             // when
             sut.deleteRoutine(previousEntities.first { it.text == text }.id)
-            val entities = sut.getRoutineListByDate(date)
+            val entities = sut.getRoutinesByDate(date)
 
             // then
             assertEquals(entities.size, previousEntities.size - 1)
@@ -124,14 +121,13 @@ class RoutineDaoTest {
             val entities =
                 createRoutineEntitiesWith(size1, date1) + createRoutineEntitiesWith(size2, date2)
 
-            sut.insertAllRoutine(entities)
+            sut.insertRoutines(entities)
 
             // when
-            sut.deleteAllRoutineByDate(date1)
-            val deletedEntities = sut.getRoutineListByDate(date1)
+            val deleteSize = sut.deleteRoutinesByDate(date1)
 
             // then
-            assertEquals(deletedEntities.size, 0)
+            assertEquals(deleteSize, entities.filter { it.date == date1 }.size)
         }
     }
 

--- a/core/data/src/main/java/com/example/data/dataSource/local/DefaultLocalDataSource.kt
+++ b/core/data/src/main/java/com/example/data/dataSource/local/DefaultLocalDataSource.kt
@@ -72,17 +72,18 @@ class DefaultLocalDataSource @Inject constructor(
         repeatRoutineDao.insertRepeatRoutine(repeatRoutine)
     }
 
-    override fun getAllRepeatRoutineListByFlow(): Flow<List<RepeatRoutineEntity>> {
-        return repeatRoutineDao.getAllRepeatRoutineListByFlow()
+    override fun getRepeatRoutinesFlow(): Flow<List<RepeatRoutineEntity>> {
+        return repeatRoutineDao.getRepeatRoutinesFlow()
     }
 
-    override suspend fun getAllRepeatRoutineList(): List<RepeatRoutineEntity> {
-        return repeatRoutineDao.getAllRepeatRoutineList()
+    override suspend fun getRepeatRoutines(): List<RepeatRoutineEntity> {
+        return repeatRoutineDao.getRepeatRoutines()
     }
 
-    override suspend fun deleteRepeatRoutine(text: String) {
-        repeatRoutineDao.deleteRepeatRoutine(text)
+    override suspend fun deleteRepeatRoutine(text: String) : Int {
+        return repeatRoutineDao.deleteRepeatRoutine(text)
     }
+
 
     override suspend fun insertCategory(category: CategoryEntity) {
         categoryDao.insertCategory(category)

--- a/core/data/src/main/java/com/example/data/dataSource/local/DefaultLocalDataSource.kt
+++ b/core/data/src/main/java/com/example/data/dataSource/local/DefaultLocalDataSource.kt
@@ -63,7 +63,7 @@ class DefaultLocalDataSource @Inject constructor(
         return reviewDao.getReviewOrNullByDate(date)
     }
 
-    override suspend fun deleteReview(review: ReviewEntity) : Int {
+    override suspend fun deleteReview(review: ReviewEntity): Int {
         return reviewDao.deleteReview(review)
     }
 
@@ -80,7 +80,7 @@ class DefaultLocalDataSource @Inject constructor(
         return repeatRoutineDao.getRepeatRoutines()
     }
 
-    override suspend fun deleteRepeatRoutine(text: String) : Int {
+    override suspend fun deleteRepeatRoutine(text: String): Int {
         return repeatRoutineDao.deleteRepeatRoutine(text)
     }
 
@@ -89,13 +89,14 @@ class DefaultLocalDataSource @Inject constructor(
         categoryDao.insertCategory(category)
     }
 
-    override fun getAllCategoryListByFlow(): Flow<List<CategoryEntity>> {
-        return categoryDao.getAllCategoryListByFlow()
+    override fun getCategoriesFlow(): Flow<List<CategoryEntity>> {
+        return categoryDao.getCategoriesFlow()
     }
 
-    override suspend fun deleteCategory(categoryEntity: CategoryEntity) {
-        categoryDao.removeCategory(categoryEntity)
+    override suspend fun deleteCategory(categoryEntity: CategoryEntity): Int {
+        return categoryDao.deleteCategory(categoryEntity)
     }
+
 
     override suspend fun getCurrentDate(): Int {
         return sharedPreferenceManager.getCurrentDate()

--- a/core/data/src/main/java/com/example/data/dataSource/local/DefaultLocalDataSource.kt
+++ b/core/data/src/main/java/com/example/data/dataSource/local/DefaultLocalDataSource.kt
@@ -17,29 +17,34 @@ class DefaultLocalDataSource @Inject constructor(
     private val sharedPreferenceManager: SharedPreferenceManager
 ) : LocalDataSource {
 
-    override fun getAllDailyRoutineByFlow(date: Int): Flow<List<RoutineEntity>> {
-        return routineDao.getAllDailyRoutineListByFlow(date)
-    }
-
     override suspend fun insertRoutine(routineEntity: RoutineEntity) {
         routineDao.insertRoutine(routineEntity)
     }
 
-    override suspend fun deleteAllRoutineByDate(date: Int) {
-        routineDao.deleteAllRoutineByDate(date)
+    override suspend fun insertRoutines(routineList: List<RoutineEntity>): List<Long> {
+        return routineDao.insertRoutines(routineList)
     }
 
-    override suspend fun deleteRoutine(id: Int) {
-        routineDao.deleteRoutine(id)
+    override fun getRoutinesFlowByDate(date: Int): Flow<List<RoutineEntity>> {
+        return routineDao.getRoutinesFlowByDate(date)
+    }
+
+    override suspend fun getRoutinesByDate(date: Int): List<RoutineEntity> {
+        return routineDao.getRoutinesByDate(date)
+    }
+
+    override suspend fun deleteRoutine(id: Int): Int {
+        return routineDao.deleteRoutine(id)
+    }
+
+    override suspend fun deleteRoutinesByDate(date: Int): Int {
+        return routineDao.deleteRoutinesByDate(date)
     }
 
     override suspend fun updateRoutine(routineEntity: RoutineEntity) {
         routineDao.updateRoutine(routineEntity)
     }
 
-    override suspend fun getRoutineListByDate(date: Int): List<RoutineEntity> {
-        return routineDao.getRoutineListByDate(date)
-    }
 
     override suspend fun insertDate(date: DateEntity) {
         return dateDao.insertDate(date)
@@ -75,10 +80,6 @@ class DefaultLocalDataSource @Inject constructor(
 
     override suspend fun deleteRepeatRoutine(text: String) {
         repeatRoutineDao.deleteRepeatRoutine(text)
-    }
-
-    override suspend fun insertAllRoutine(routineList: List<RoutineEntity>) {
-        routineDao.insertAllRoutine(routineList)
     }
 
     override suspend fun insertCategory(category: CategoryEntity) {

--- a/core/data/src/main/java/com/example/data/dataSource/local/DefaultLocalDataSource.kt
+++ b/core/data/src/main/java/com/example/data/dataSource/local/DefaultLocalDataSource.kt
@@ -54,17 +54,19 @@ class DefaultLocalDataSource @Inject constructor(
         return dateDao.getAllDateList()
     }
 
-    override suspend fun getReviewOrNullByDate(date: Int): ReviewEntity? {
-        return reviewDao.getReviewOrNullByDate(date)
-    }
 
     override suspend fun insertReview(review: ReviewEntity) {
         reviewDao.insertReview(review)
     }
 
-    override suspend fun deleteReview(review: ReviewEntity) {
-        reviewDao.deleteReview(review)
+    override suspend fun getReviewOrNullByDate(date: Int): ReviewEntity? {
+        return reviewDao.getReviewOrNullByDate(date)
     }
+
+    override suspend fun deleteReview(review: ReviewEntity) : Int {
+        return reviewDao.deleteReview(review)
+    }
+
 
     override suspend fun insertRepeatRoutine(repeatRoutine: RepeatRoutineEntity) {
         repeatRoutineDao.insertRepeatRoutine(repeatRoutine)

--- a/core/data/src/main/java/com/example/data/dataSource/local/DefaultLocalDataSource.kt
+++ b/core/data/src/main/java/com/example/data/dataSource/local/DefaultLocalDataSource.kt
@@ -50,8 +50,8 @@ class DefaultLocalDataSource @Inject constructor(
         return dateDao.insertDate(date)
     }
 
-    override suspend fun getAllDateList(): List<DateEntity> {
-        return dateDao.getAllDateList()
+    override suspend fun getDateList(): List<DateEntity> {
+        return dateDao.getDateList()
     }
 
 

--- a/core/data/src/main/java/com/example/data/dataSource/local/LocalDataSource.kt
+++ b/core/data/src/main/java/com/example/data/dataSource/local/LocalDataSource.kt
@@ -5,17 +5,20 @@ import kotlinx.coroutines.flow.Flow
 
 interface LocalDataSource {
 
-    fun getAllDailyRoutineByFlow(date : Int) : Flow<List<RoutineEntity>>
-
     suspend fun insertRoutine(routineEntity: RoutineEntity)
 
-    suspend fun deleteAllRoutineByDate(date : Int)
+    suspend fun insertRoutines(routineList: List<RoutineEntity>) : List<Long>
 
-    suspend fun deleteRoutine(id : Int)
+    fun getRoutinesFlowByDate(date : Int) : Flow<List<RoutineEntity>>
+
+    suspend fun getRoutinesByDate(date :Int) : List<RoutineEntity>
+
+    suspend fun deleteRoutinesByDate(date : Int) : Int
+
+    suspend fun deleteRoutine(id : Int) : Int
 
     suspend fun updateRoutine(routineEntity: RoutineEntity)
 
-    suspend fun getRoutineListByDate(date :Int) : List<RoutineEntity>
 
     suspend fun insertDate(date : DateEntity)
 
@@ -34,8 +37,6 @@ interface LocalDataSource {
     suspend fun getAllRepeatRoutineList() : List<RepeatRoutineEntity>
 
     suspend fun deleteRepeatRoutine(text: String)
-
-    suspend fun insertAllRoutine(routineList: List<RoutineEntity>)
 
     suspend fun insertCategory(category: CategoryEntity)
 

--- a/core/data/src/main/java/com/example/data/dataSource/local/LocalDataSource.kt
+++ b/core/data/src/main/java/com/example/data/dataSource/local/LocalDataSource.kt
@@ -22,7 +22,7 @@ interface LocalDataSource {
 
     suspend fun insertDate(date : DateEntity)
 
-    suspend fun getAllDateList() : List<DateEntity>
+    suspend fun getDateList() : List<DateEntity>
 
 
     suspend fun insertReview(review : ReviewEntity)

--- a/core/data/src/main/java/com/example/data/dataSource/local/LocalDataSource.kt
+++ b/core/data/src/main/java/com/example/data/dataSource/local/LocalDataSource.kt
@@ -34,11 +34,12 @@ interface LocalDataSource {
 
     suspend fun insertRepeatRoutine(repeatRoutine: RepeatRoutineEntity)
 
-    fun getAllRepeatRoutineListByFlow() : Flow<List<RepeatRoutineEntity>>
+    fun getRepeatRoutinesFlow() : Flow<List<RepeatRoutineEntity>>
 
-    suspend fun getAllRepeatRoutineList() : List<RepeatRoutineEntity>
+    suspend fun getRepeatRoutines() : List<RepeatRoutineEntity>
 
-    suspend fun deleteRepeatRoutine(text: String)
+    suspend fun deleteRepeatRoutine(text: String) : Int
+
 
     suspend fun insertCategory(category: CategoryEntity)
 

--- a/core/data/src/main/java/com/example/data/dataSource/local/LocalDataSource.kt
+++ b/core/data/src/main/java/com/example/data/dataSource/local/LocalDataSource.kt
@@ -43,9 +43,10 @@ interface LocalDataSource {
 
     suspend fun insertCategory(category: CategoryEntity)
 
-    fun getAllCategoryListByFlow() : Flow<List<CategoryEntity>>
+    fun getCategoriesFlow() : Flow<List<CategoryEntity>>
 
-    suspend fun deleteCategory(categoryEntity : CategoryEntity)
+    suspend fun deleteCategory(categoryEntity : CategoryEntity) : Int
+
 
     suspend fun getCurrentDate() : Int
 

--- a/core/data/src/main/java/com/example/data/dataSource/local/LocalDataSource.kt
+++ b/core/data/src/main/java/com/example/data/dataSource/local/LocalDataSource.kt
@@ -24,11 +24,13 @@ interface LocalDataSource {
 
     suspend fun getAllDateList() : List<DateEntity>
 
-    suspend fun getReviewOrNullByDate(date : Int) : ReviewEntity?
 
     suspend fun insertReview(review : ReviewEntity)
 
-    suspend fun deleteReview(review: ReviewEntity)
+    suspend fun getReviewOrNullByDate(date : Int) : ReviewEntity?
+
+    suspend fun deleteReview(review: ReviewEntity) : Int
+
 
     suspend fun insertRepeatRoutine(repeatRoutine: RepeatRoutineEntity)
 

--- a/core/data/src/main/java/com/example/data/db/dao/CategoryDao.kt
+++ b/core/data/src/main/java/com/example/data/db/dao/CategoryDao.kt
@@ -15,9 +15,9 @@ interface CategoryDao {
     suspend fun insertCategory(categoryEntity: CategoryEntity)
 
     @Query("SELECT * FROM category")
-    fun getAllCategoryListByFlow() : Flow<List<CategoryEntity>>
+    fun getCategoriesFlow() : Flow<List<CategoryEntity>>
 
     @Delete
-    suspend fun removeCategory(categoryEntity : CategoryEntity)
+    suspend fun deleteCategory(categoryEntity : CategoryEntity) : Int
 
 }

--- a/core/data/src/main/java/com/example/data/db/dao/DateDao.kt
+++ b/core/data/src/main/java/com/example/data/db/dao/DateDao.kt
@@ -13,6 +13,6 @@ interface DateDao {
     fun insertDate(dateEntity: DateEntity)
 
     @Query("SELECT * FROM routineDate")
-    suspend fun getAllDateList(): List<DateEntity>
+    suspend fun getDateList(): List<DateEntity>
 
 }

--- a/core/data/src/main/java/com/example/data/db/dao/RepeatRoutineDao.kt
+++ b/core/data/src/main/java/com/example/data/db/dao/RepeatRoutineDao.kt
@@ -11,12 +11,12 @@ interface RepeatRoutineDao {
     suspend fun insertRepeatRoutine(repeatRoutineEntity: RepeatRoutineEntity)
 
     @Query("SELECT * FROM repeatRoutine")
-    fun getAllRepeatRoutineListByFlow(): Flow<List<RepeatRoutineEntity>>
+    fun getRepeatRoutinesFlow(): Flow<List<RepeatRoutineEntity>>
 
     @Query("SELECT * FROM repeatRoutine")
-    suspend fun getAllRepeatRoutineList(): List<RepeatRoutineEntity>
+    suspend fun getRepeatRoutines(): List<RepeatRoutineEntity>
 
     @Query("DELETE FROM repeatRoutine WHERE text = :text")
-    suspend fun deleteRepeatRoutine(text: String)
+    suspend fun deleteRepeatRoutine(text: String) : Int
 
 }

--- a/core/data/src/main/java/com/example/data/db/dao/ReviewDao.kt
+++ b/core/data/src/main/java/com/example/data/db/dao/ReviewDao.kt
@@ -12,6 +12,6 @@ interface ReviewDao {
     suspend fun getReviewOrNullByDate(date: Int): ReviewEntity?
 
     @Delete
-    fun deleteReview(reviewEntity: ReviewEntity)
+    fun deleteReview(reviewEntity: ReviewEntity) : Int
 
 }

--- a/core/data/src/main/java/com/example/data/db/dao/RoutineDao.kt
+++ b/core/data/src/main/java/com/example/data/db/dao/RoutineDao.kt
@@ -8,22 +8,22 @@ import kotlinx.coroutines.flow.Flow
 interface RoutineDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertAllRoutine(routineEntityList: List<RoutineEntity>)
+    suspend fun insertRoutines(routineEntityList: List<RoutineEntity>) : List<Long>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertRoutine(routineEntity: RoutineEntity)
 
     @Query("SELECT * FROM routine WHERE date = :date")
-    fun getAllDailyRoutineListByFlow(date: Int): Flow<List<RoutineEntity>>
+    fun getRoutinesFlowByDate(date: Int): Flow<List<RoutineEntity>>
 
     @Query("SELECT * FROM routine WHERE date = :date")
-    suspend fun getRoutineListByDate(date: Int): List<RoutineEntity>
+    suspend fun getRoutinesByDate(date: Int): List<RoutineEntity>
 
     @Query("DELETE FROM routine WHERE date = :date")
-    suspend fun deleteAllRoutineByDate(date: Int)
+    suspend fun deleteRoutinesByDate(date: Int) : Int
 
     @Query("DELETE FROM routine WHERE id = :id")
-    suspend fun deleteRoutine(id: Int)
+    suspend fun deleteRoutine(id: Int) : Int
 
     @Update
     suspend fun updateRoutine(routineEntity: RoutineEntity)

--- a/core/data/src/main/java/com/example/data/repository/DefaultRepository.kt
+++ b/core/data/src/main/java/com/example/data/repository/DefaultRepository.kt
@@ -48,7 +48,7 @@ class DefaultRepository @Inject constructor(
     }
 
     override suspend fun getAllDateList(): List<Date> {
-        return localDataSource.getAllDateList().toDateList()
+        return localDataSource.getDateList().toDateList()
     }
 
 

--- a/core/data/src/main/java/com/example/data/repository/DefaultRepository.kt
+++ b/core/data/src/main/java/com/example/data/repository/DefaultRepository.kt
@@ -66,7 +66,7 @@ class DefaultRepository @Inject constructor(
 
 
     override suspend fun insertAllDailyRoutineFromRepeatRoutine(dayOfWeek: String) {
-        val repeatRoutineList = localDataSource.getAllRepeatRoutineList()
+        val repeatRoutineList = localDataSource.getRepeatRoutines()
         repeatRoutineList.filter { it.dayOfWeekList.contains(dayOfWeek) }.toRoutineEntityList().let { routineEntityList ->
             localDataSource.insertRoutines(routineEntityList)
         }
@@ -77,11 +77,11 @@ class DefaultRepository @Inject constructor(
     }
 
     override fun getAllRepeatRoutineListByFlow(): Flow<List<RepeatRoutine>> {
-        return localDataSource.getAllRepeatRoutineListByFlow().map { it.toRepeatRoutineList() }
+        return localDataSource.getRepeatRoutinesFlow().map { it.toRepeatRoutineList() }
     }
 
     override suspend fun getAllRepeatRoutineList(): List<RepeatRoutine> {
-        return localDataSource.getAllRepeatRoutineList().toRepeatRoutineList()
+        return localDataSource.getRepeatRoutines().toRepeatRoutineList()
     }
 
     override suspend fun deleteRepeatRoutine(text: String) {

--- a/core/data/src/main/java/com/example/data/repository/DefaultRepository.kt
+++ b/core/data/src/main/java/com/example/data/repository/DefaultRepository.kt
@@ -15,7 +15,7 @@ class DefaultRepository @Inject constructor(
 ) : Repository {
 
     override suspend fun insertAllRoutine(routineList: List<Routine>) {
-        localDataSource.insertAllRoutine(routineList.toRoutineEntity())
+        localDataSource.insertRoutines(routineList.toRoutineEntity())
     }
 
     override suspend fun insertRoutine(routine: Routine) {
@@ -23,11 +23,11 @@ class DefaultRepository @Inject constructor(
     }
 
     override fun getAllDailyRoutineByFlow(date: Int): Flow<List<Routine>> {
-        return localDataSource.getAllDailyRoutineByFlow(date).map { it.toRoutineList() }
+        return localDataSource.getRoutinesFlowByDate(date).map { it.toRoutineList() }
     }
 
     override suspend fun getRoutineListByDate(date: Int): List<Routine> {
-        return localDataSource.getRoutineListByDate(date).toRoutineList()
+        return localDataSource.getRoutinesByDate(date).toRoutineList()
     }
 
     override suspend fun updateRoutine(routine: Routine) {
@@ -35,7 +35,7 @@ class DefaultRepository @Inject constructor(
     }
 
     override suspend fun deleteAllRoutineByDate(date: Int) {
-        localDataSource.deleteAllRoutineByDate(date)
+        localDataSource.deleteRoutinesByDate(date)
     }
 
     override suspend fun deleteRoutine(id: Int) {
@@ -68,7 +68,7 @@ class DefaultRepository @Inject constructor(
     override suspend fun insertAllDailyRoutineFromRepeatRoutine(dayOfWeek: String) {
         val repeatRoutineList = localDataSource.getAllRepeatRoutineList()
         repeatRoutineList.filter { it.dayOfWeekList.contains(dayOfWeek) }.toRoutineEntityList().let { routineEntityList ->
-            localDataSource.insertAllRoutine(routineEntityList)
+            localDataSource.insertRoutines(routineEntityList)
         }
     }
 

--- a/core/data/src/main/java/com/example/data/repository/DefaultRepository.kt
+++ b/core/data/src/main/java/com/example/data/repository/DefaultRepository.kt
@@ -94,7 +94,7 @@ class DefaultRepository @Inject constructor(
     }
 
     override fun getAllCategoryListByFlow(): Flow<List<Category>> {
-        return localDataSource.getAllCategoryListByFlow().map { it.toCategory() }
+        return localDataSource.getCategoriesFlow().map { it.toCategory() }
     }
 
     override suspend fun deleteCategory(category: Category) {

--- a/core/data/src/test/java/com/example/data/repository/CategoryRepositoryTest.kt
+++ b/core/data/src/test/java/com/example/data/repository/CategoryRepositoryTest.kt
@@ -47,14 +47,14 @@ class CategoryRepositoryTest {
         runBlocking {
             // given
             val categoryEntitiesByFlow = flowOf(listOf(CategoryEntity("운동")))
-            whenever(localDateSource.getAllCategoryListByFlow()).thenReturn(categoryEntitiesByFlow)
+            whenever(localDateSource.getCategoriesFlow()).thenReturn(categoryEntitiesByFlow)
 
             // when
             val categoriesByFlow = sut.getAllCategoryListByFlow()
 
             // then
             assertThat(categoriesByFlow.first().size).isEqualTo(categoryEntitiesByFlow.first().size)
-            verify(localDateSource).getAllCategoryListByFlow()
+            verify(localDateSource).getCategoriesFlow()
         }
     }
 
@@ -63,7 +63,7 @@ class CategoryRepositoryTest {
         runBlocking {
             // given
             val category = Category("운동")
-            whenever(localDateSource.deleteCategory(category.toCategoryEntity())).thenReturn(Unit)
+            whenever(localDateSource.deleteCategory(category.toCategoryEntity())).thenReturn(1)
 
             // when
             sut.deleteCategory(category)

--- a/core/data/src/test/java/com/example/data/repository/DateRepositoryTest.kt
+++ b/core/data/src/test/java/com/example/data/repository/DateRepositoryTest.kt
@@ -42,14 +42,14 @@ class DateRepositoryTest {
         runBlocking {
             // given
             val dateEntities = listOf(DateEntity(20250228), DateEntity(20250227))
-            whenever(localDateSource.getAllDateList()).thenReturn(dateEntities)
+            whenever(localDateSource.getDateList()).thenReturn(dateEntities)
 
             // when
             val dateList = sut.getAllDateList()
 
             // then
             assertThat(dateList.size).isEqualTo(dateEntities.size)
-            verify(localDateSource).getAllDateList()
+            verify(localDateSource).getDateList()
         }
     }
 }

--- a/core/data/src/test/java/com/example/data/repository/RepeatRoutineRepositoryTest.kt
+++ b/core/data/src/test/java/com/example/data/repository/RepeatRoutineRepositoryTest.kt
@@ -30,14 +30,14 @@ class RepeatRoutineRepositoryTest {
         runBlocking {
             // given
             val dayOfWeek = "월"
-            whenever(localDateSource.getAllRepeatRoutineList()).thenReturn(listOf())
+            whenever(localDateSource.getRepeatRoutines()).thenReturn(listOf())
             whenever(localDateSource.insertRoutines(listOf())).thenReturn(listOf())
 
             // when
             sut.insertAllDailyRoutineFromRepeatRoutine(dayOfWeek)
 
             // then
-            verify(localDateSource).getAllRepeatRoutineList()
+            verify(localDateSource).getRepeatRoutines()
             verify(localDateSource).insertRoutines(listOf())
         }
     }
@@ -62,14 +62,14 @@ class RepeatRoutineRepositoryTest {
         runBlocking {
             // given
             val repeatRoutineEntitiesByFlow = flowOf(listOf(RepeatRoutineEntity(dayOfWeekList = listOf("월"))))
-            whenever(localDateSource.getAllRepeatRoutineListByFlow()).thenReturn(repeatRoutineEntitiesByFlow)
+            whenever(localDateSource.getRepeatRoutinesFlow()).thenReturn(repeatRoutineEntitiesByFlow)
 
             // when
             val repeatRoutinesByFlow = sut.getAllRepeatRoutineListByFlow()
 
             // then
             assertThat(repeatRoutinesByFlow.first().size).isEqualTo(repeatRoutineEntitiesByFlow.first().size)
-            verify(localDateSource).getAllRepeatRoutineListByFlow()
+            verify(localDateSource).getRepeatRoutinesFlow()
         }
     }
 
@@ -78,14 +78,14 @@ class RepeatRoutineRepositoryTest {
         runBlocking {
             // given
             val repeatRoutineEntities = listOf(RepeatRoutineEntity(dayOfWeekList = listOf("월")))
-            whenever(localDateSource.getAllRepeatRoutineList()).thenReturn(repeatRoutineEntities)
+            whenever(localDateSource.getRepeatRoutines()).thenReturn(repeatRoutineEntities)
 
             // when
             val repeatRoutines = sut.getAllRepeatRoutineList()
 
             // then
             assertThat(repeatRoutines.size).isEqualTo(repeatRoutineEntities.size)
-            verify(localDateSource).getAllRepeatRoutineList()
+            verify(localDateSource).getRepeatRoutines()
         }
     }
 
@@ -94,7 +94,7 @@ class RepeatRoutineRepositoryTest {
         runBlocking {
             // given
             val text = ""
-            whenever(localDateSource.deleteRepeatRoutine(text)).thenReturn(Unit)
+            whenever(localDateSource.deleteRepeatRoutine(text)).thenReturn(1)
 
             // when
             sut.deleteRepeatRoutine(text)

--- a/core/data/src/test/java/com/example/data/repository/RepeatRoutineRepositoryTest.kt
+++ b/core/data/src/test/java/com/example/data/repository/RepeatRoutineRepositoryTest.kt
@@ -31,14 +31,14 @@ class RepeatRoutineRepositoryTest {
             // given
             val dayOfWeek = "월"
             whenever(localDateSource.getAllRepeatRoutineList()).thenReturn(listOf())
-            whenever(localDateSource.insertAllRoutine(listOf())).thenReturn(Unit)
+            whenever(localDateSource.insertRoutines(listOf())).thenReturn(listOf())
 
             // when
             sut.insertAllDailyRoutineFromRepeatRoutine(dayOfWeek)
 
             // then
             verify(localDateSource).getAllRepeatRoutineList()
-            verify(localDateSource).insertAllRoutine(listOf())
+            verify(localDateSource).insertRoutines(listOf())
         }
     }
 

--- a/core/data/src/test/java/com/example/data/repository/ReviewRepositoryTest.kt
+++ b/core/data/src/test/java/com/example/data/repository/ReviewRepositoryTest.kt
@@ -77,7 +77,7 @@ class ReviewRepositoryTest {
         runBlocking {
             // given
             val review = Review(date, "")
-            whenever(localDateSource.deleteReview(review.toReviewEntity())).thenReturn(Unit)
+            whenever(localDateSource.deleteReview(review.toReviewEntity())).thenReturn(1)
 
             // when
             sut.deleteReview(review)

--- a/core/data/src/test/java/com/example/data/repository/RoutineRepositoryTest.kt
+++ b/core/data/src/test/java/com/example/data/repository/RoutineRepositoryTest.kt
@@ -32,13 +32,13 @@ class RoutineRepositoryTest {
         runBlocking {
             // given
             val routines = createRoutines(5, date)
-            whenever(localDateSource.insertAllRoutine(routines.toRoutineEntity())).thenReturn(Unit)
+            whenever(localDateSource.insertRoutines(routines.toRoutineEntity())).thenReturn(listOf(1,2,3,4,5))
 
             // when
             sut.insertAllRoutine(routines)
 
             // then
-            verify(localDateSource).insertAllRoutine(routines.toRoutineEntity())
+            verify(localDateSource).insertRoutines(routines.toRoutineEntity())
 
         }
 
@@ -65,7 +65,7 @@ class RoutineRepositoryTest {
             // given
             val size = 5
             val routineEntities = createRoutineEntities(size, date)
-            whenever(localDateSource.getAllDailyRoutineByFlow(date)).thenReturn(flowOf(routineEntities))
+            whenever(localDateSource.getRoutinesFlowByDate(date)).thenReturn(flowOf(routineEntities))
 
             // when
             val routinesByFlow = sut.getAllDailyRoutineByFlow(date)
@@ -73,7 +73,7 @@ class RoutineRepositoryTest {
             // then
             assertThat(routinesByFlow.first().size).isEqualTo(size)
             assertThat(routinesByFlow.first().all { it.date == date }).isTrue()
-            verify(localDateSource).getAllDailyRoutineByFlow(date)
+            verify(localDateSource).getRoutinesFlowByDate(date)
         }
     }
 
@@ -83,7 +83,7 @@ class RoutineRepositoryTest {
             // given
             val size = 5
             val routineEntities = createRoutineEntities(size, date)
-            whenever(localDateSource.getRoutineListByDate(date)).thenReturn(routineEntities)
+            whenever(localDateSource.getRoutinesByDate(date)).thenReturn(routineEntities)
 
             // when
             val routines = sut.getRoutineListByDate(date)
@@ -91,7 +91,7 @@ class RoutineRepositoryTest {
             // then
             assertThat(routines.size).isEqualTo(size)
             assertThat(routines.all { it.date == date }).isTrue()
-            verify(localDateSource).getRoutineListByDate(date)
+            verify(localDateSource).getRoutinesByDate(date)
         }
     }
 
@@ -114,13 +114,13 @@ class RoutineRepositoryTest {
     fun givenDate_whenDeleteRoutines_thenWorksFine() {
         runBlocking {
             // given
-            whenever(localDateSource.deleteAllRoutineByDate(date)).thenReturn(Unit)
+            whenever(localDateSource.deleteRoutinesByDate(date)).thenReturn(3)
 
             // when
             sut.deleteAllRoutineByDate(date)
 
             // then
-            verify(localDateSource).deleteAllRoutineByDate(date)
+            verify(localDateSource).deleteRoutinesByDate(date)
         }
     }
 
@@ -129,7 +129,7 @@ class RoutineRepositoryTest {
         runBlocking {
             // given
             val routineId = 1
-            whenever(localDateSource.deleteRoutine(routineId)).thenReturn(Unit)
+            whenever(localDateSource.deleteRoutine(routineId)).thenReturn(1)
 
             // when
             sut.deleteRoutine(routineId)


### PR DESCRIPTION
엔티티 다중 추가, 삭제시 삭제한 갯수를 반환하도록 Dao 반환형 설정

메서드 이름 변경
- getAllRoutineList -> getRoutines
이름에 컬렉션을 빼고 엔티티의 복수형으로 작성

- getDateList
이 경우 Date의 복수형이 없으므로 getDateList 그대로 사용하기로 결정

This closes #74 