### PR TITLE
Repository 메서드명, 반환타입 수정

### DIFF
--- a/core/data/src/main/java/com/example/data/repository/DefaultCategoryRepository.kt
+++ b/core/data/src/main/java/com/example/data/repository/DefaultCategoryRepository.kt
@@ -19,12 +19,12 @@ class DefaultCategoryRepository @Inject constructor(
         localDataSource.insertCategory(category.toCategoryEntity())
     }
 
-    override fun getAllCategoryListByFlow(): Flow<List<Category>> {
+    override fun getCategoriesFlow(): Flow<List<Category>> {
         return localDataSource.getCategoriesFlow().map { it.toCategory() }
     }
 
-    override suspend fun deleteCategory(category: Category) {
-        localDataSource.deleteCategory(category.toCategoryEntity())
+    override suspend fun deleteCategory(category: Category): Int {
+        return localDataSource.deleteCategory(category.toCategoryEntity())
     }
 
 }

--- a/core/data/src/main/java/com/example/data/repository/DefaultDateRepository.kt
+++ b/core/data/src/main/java/com/example/data/repository/DefaultDateRepository.kt
@@ -17,7 +17,7 @@ class DefaultDateRepository @Inject constructor(
         return localDataSource.insertDate(Date(date).toDateEntity())
     }
 
-    override suspend fun getAllDateList(): List<Date> {
+    override suspend fun getDateList(): List<Date> {
         return localDataSource.getDateList().toDateList()
     }
 

--- a/core/data/src/main/java/com/example/data/repository/DefaultRepeatRoutineRepository.kt
+++ b/core/data/src/main/java/com/example/data/repository/DefaultRepeatRoutineRepository.kt
@@ -19,16 +19,16 @@ class DefaultRepeatRoutineRepository @Inject constructor(
         localDataSource.insertRepeatRoutine(repeatRoutine.toRepeatRoutineEntity())
     }
 
-    override fun getAllRepeatRoutineListByFlow(): Flow<List<RepeatRoutine>> {
+    override fun getRepeatRoutinesFlow(): Flow<List<RepeatRoutine>> {
         return localDataSource.getRepeatRoutinesFlow().map { it.toRepeatRoutineList() }
     }
 
-    override suspend fun getAllRepeatRoutineList(): List<RepeatRoutine> {
+    override suspend fun getRepeatRoutines(): List<RepeatRoutine> {
         return localDataSource.getRepeatRoutines().toRepeatRoutineList()
     }
 
-    override suspend fun deleteRepeatRoutine(text: String) {
-        localDataSource.deleteRepeatRoutine(text)
+    override suspend fun deleteRepeatRoutine(text: String) : Int {
+        return localDataSource.deleteRepeatRoutine(text)
     }
 
 }

--- a/core/data/src/main/java/com/example/data/repository/DefaultReviewRepository.kt
+++ b/core/data/src/main/java/com/example/data/repository/DefaultReviewRepository.kt
@@ -21,8 +21,8 @@ class DefaultReviewRepository @Inject constructor(
         localDataSource.insertReview(review.toReviewEntity())
     }
 
-    override suspend fun deleteReview(review: Review) {
-        localDataSource.deleteReview(review.toReviewEntity())
+    override suspend fun deleteReview(review: Review) : Int {
+        return localDataSource.deleteReview(review.toReviewEntity())
     }
 
 }

--- a/core/data/src/main/java/com/example/data/repository/DefaultRoutineRepository.kt
+++ b/core/data/src/main/java/com/example/data/repository/DefaultRoutineRepository.kt
@@ -16,14 +16,14 @@ class DefaultRoutineRepository @Inject constructor(
     private val localDataSource: LocalDataSource
 ) : RoutineRepository {
 
-    override suspend fun insertAllDailyRoutineFromRepeatRoutine(dayOfWeek: String) {
+    override suspend fun insertRoutinesFromRepeatRoutineByDayOfWeek(dayOfWeek: String) {
         val repeatRoutineList = localDataSource.getRepeatRoutines()
         repeatRoutineList.filter { it.dayOfWeekList.contains(dayOfWeek) }.toRoutineEntityList().let { routineEntityList ->
             localDataSource.insertRoutines(routineEntityList)
         }
     }
 
-    override suspend fun insertAllRoutine(routineList: List<Routine>) {
+    override suspend fun insertRoutines(routineList: List<Routine>) {
         localDataSource.insertRoutines(routineList.toRoutineEntity())
     }
 
@@ -31,11 +31,11 @@ class DefaultRoutineRepository @Inject constructor(
         localDataSource.insertRoutine(routine.toRoutineEntity())
     }
 
-    override fun getAllDailyRoutineByFlow(date: Int): Flow<List<Routine>> {
+    override fun getRoutinesFlowByDate(date: Int): Flow<List<Routine>> {
         return localDataSource.getRoutinesFlowByDate(date).map { it.toRoutineList() }
     }
 
-    override suspend fun getRoutineListByDate(date: Int): List<Routine> {
+    override suspend fun getRoutinesByDate(date: Int): List<Routine> {
         return localDataSource.getRoutinesByDate(date).toRoutineList()
     }
 
@@ -43,7 +43,7 @@ class DefaultRoutineRepository @Inject constructor(
         localDataSource.updateRoutine(routine.toRoutineEntity())
     }
 
-    override suspend fun deleteAllRoutineByDate(date: Int) {
+    override suspend fun deleteRoutinesByDate(date: Int) {
         localDataSource.deleteRoutinesByDate(date)
     }
 

--- a/core/data/src/main/java/com/example/data/repository/DefaultRoutineRepository.kt
+++ b/core/data/src/main/java/com/example/data/repository/DefaultRoutineRepository.kt
@@ -16,15 +16,16 @@ class DefaultRoutineRepository @Inject constructor(
     private val localDataSource: LocalDataSource
 ) : RoutineRepository {
 
-    override suspend fun insertRoutinesFromRepeatRoutineByDayOfWeek(dayOfWeek: String) {
+    override suspend fun insertRoutinesFromRepeatRoutineByDayOfWeek(dayOfWeek: String): List<Long> {
         val repeatRoutineList = localDataSource.getRepeatRoutines()
-        repeatRoutineList.filter { it.dayOfWeekList.contains(dayOfWeek) }.toRoutineEntityList().let { routineEntityList ->
-            localDataSource.insertRoutines(routineEntityList)
-        }
+        repeatRoutineList.filter { it.dayOfWeekList.contains(dayOfWeek) }.toRoutineEntityList()
+            .let { routineEntityList ->
+                return localDataSource.insertRoutines(routineEntityList)
+            }
     }
 
-    override suspend fun insertRoutines(routineList: List<Routine>) {
-        localDataSource.insertRoutines(routineList.toRoutineEntity())
+    override suspend fun insertRoutines(routineList: List<Routine>): List<Long> {
+        return localDataSource.insertRoutines(routineList.toRoutineEntity())
     }
 
     override suspend fun insertRoutine(routine: Routine) {
@@ -43,12 +44,12 @@ class DefaultRoutineRepository @Inject constructor(
         localDataSource.updateRoutine(routine.toRoutineEntity())
     }
 
-    override suspend fun deleteRoutinesByDate(date: Int) {
-        localDataSource.deleteRoutinesByDate(date)
+    override suspend fun deleteRoutinesByDate(date: Int): Int {
+        return localDataSource.deleteRoutinesByDate(date)
     }
 
-    override suspend fun deleteRoutine(id: Int) {
-        localDataSource.deleteRoutine(id)
+    override suspend fun deleteRoutine(id: Int): Int {
+        return localDataSource.deleteRoutine(id)
     }
 
 }

--- a/core/data/src/test/java/com/example/data/repository/CategoryRepositoryTest.kt
+++ b/core/data/src/test/java/com/example/data/repository/CategoryRepositoryTest.kt
@@ -50,7 +50,7 @@ class CategoryRepositoryTest {
             whenever(localDateSource.getCategoriesFlow()).thenReturn(categoryEntitiesByFlow)
 
             // when
-            val categoriesByFlow = sut.getAllCategoryListByFlow()
+            val categoriesByFlow = sut.getCategoriesFlow()
 
             // then
             assertThat(categoriesByFlow.first().size).isEqualTo(categoryEntitiesByFlow.first().size)
@@ -66,9 +66,10 @@ class CategoryRepositoryTest {
             whenever(localDateSource.deleteCategory(category.toCategoryEntity())).thenReturn(1)
 
             // when
-            sut.deleteCategory(category)
+            val deleteCount = sut.deleteCategory(category)
 
             // then
+            assertThat(deleteCount).isEqualTo(listOf(category).size)
             verify(localDateSource).deleteCategory(category.toCategoryEntity())
         }
     }

--- a/core/data/src/test/java/com/example/data/repository/DateRepositoryTest.kt
+++ b/core/data/src/test/java/com/example/data/repository/DateRepositoryTest.kt
@@ -45,7 +45,7 @@ class DateRepositoryTest {
             whenever(localDateSource.getDateList()).thenReturn(dateEntities)
 
             // when
-            val dateList = sut.getAllDateList()
+            val dateList = sut.getDateList()
 
             // then
             assertThat(dateList.size).isEqualTo(dateEntities.size)

--- a/core/data/src/test/java/com/example/data/repository/RepeatRoutineRepositoryTest.kt
+++ b/core/data/src/test/java/com/example/data/repository/RepeatRoutineRepositoryTest.kt
@@ -48,7 +48,7 @@ class RepeatRoutineRepositoryTest {
             whenever(localDateSource.getRepeatRoutinesFlow()).thenReturn(repeatRoutineEntitiesByFlow)
 
             // when
-            val repeatRoutinesByFlow = sut.getAllRepeatRoutineListByFlow()
+            val repeatRoutinesByFlow = sut.getRepeatRoutinesFlow()
 
             // then
             assertThat(repeatRoutinesByFlow.first().size).isEqualTo(repeatRoutineEntitiesByFlow.first().size)
@@ -64,7 +64,7 @@ class RepeatRoutineRepositoryTest {
             whenever(localDateSource.getRepeatRoutines()).thenReturn(repeatRoutineEntities)
 
             // when
-            val repeatRoutines = sut.getAllRepeatRoutineList()
+            val repeatRoutines = sut.getRepeatRoutines()
 
             // then
             assertThat(repeatRoutines.size).isEqualTo(repeatRoutineEntities.size)
@@ -80,9 +80,10 @@ class RepeatRoutineRepositoryTest {
             whenever(localDateSource.deleteRepeatRoutine(text)).thenReturn(1)
 
             // when
-            sut.deleteRepeatRoutine(text)
+            val deleteCount = sut.deleteRepeatRoutine(text)
 
             // then
+            assertThat(deleteCount).isEqualTo(listOf(text).size)
             verify(localDateSource).deleteRepeatRoutine(text)
         }
     }

--- a/core/data/src/test/java/com/example/data/repository/ReviewRepositoryTest.kt
+++ b/core/data/src/test/java/com/example/data/repository/ReviewRepositoryTest.kt
@@ -80,9 +80,10 @@ class ReviewRepositoryTest {
             whenever(localDateSource.deleteReview(review.toReviewEntity())).thenReturn(1)
 
             // when
-            sut.deleteReview(review)
+            val deleteCount = sut.deleteReview(review)
 
             // then
+            assertThat(deleteCount).isEqualTo(listOf(review).size)
             verify(localDateSource).deleteReview(review.toReviewEntity())
         }
     }

--- a/core/data/src/test/java/com/example/data/repository/RoutineRepositoryTest.kt
+++ b/core/data/src/test/java/com/example/data/repository/RoutineRepositoryTest.kt
@@ -36,7 +36,7 @@ class RoutineRepositoryTest {
             whenever(localDateSource.insertRoutines(listOf())).thenReturn(listOf())
 
             // when
-            sut.insertAllDailyRoutineFromRepeatRoutine(dayOfWeek)
+            sut.insertRoutinesFromRepeatRoutineByDayOfWeek(dayOfWeek)
 
             // then
             verify(localDateSource).getRepeatRoutines()
@@ -52,7 +52,7 @@ class RoutineRepositoryTest {
             whenever(localDateSource.insertRoutines(routines.toRoutineEntity())).thenReturn(listOf(1,2,3,4,5))
 
             // when
-            sut.insertAllRoutine(routines)
+            sut.insertRoutines(routines)
 
             // then
             verify(localDateSource).insertRoutines(routines.toRoutineEntity())
@@ -85,7 +85,7 @@ class RoutineRepositoryTest {
             whenever(localDateSource.getRoutinesFlowByDate(date)).thenReturn(flowOf(routineEntities))
 
             // when
-            val routinesByFlow = sut.getAllDailyRoutineByFlow(date)
+            val routinesByFlow = sut.getRoutinesFlowByDate(date)
 
             // then
             assertThat(routinesByFlow.first().size).isEqualTo(size)
@@ -103,7 +103,7 @@ class RoutineRepositoryTest {
             whenever(localDateSource.getRoutinesByDate(date)).thenReturn(routineEntities)
 
             // when
-            val routines = sut.getRoutineListByDate(date)
+            val routines = sut.getRoutinesByDate(date)
 
             // then
             assertThat(routines.size).isEqualTo(size)
@@ -134,7 +134,7 @@ class RoutineRepositoryTest {
             whenever(localDateSource.deleteRoutinesByDate(date)).thenReturn(3)
 
             // when
-            sut.deleteAllRoutineByDate(date)
+            sut.deleteRoutinesByDate(date)
 
             // then
             verify(localDateSource).deleteRoutinesByDate(date)

--- a/core/data/src/test/java/com/example/data/repository/RoutineRepositoryTest.kt
+++ b/core/data/src/test/java/com/example/data/repository/RoutineRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.example.data.repository
 
 import com.example.data.dataSource.local.DefaultLocalDataSource
+import com.example.data.entity.RepeatRoutineEntity
 import com.example.data.entity.RoutineEntity
 import com.example.data.mapper.toRoutineEntity
 import com.example.domain.model.Routine
@@ -31,14 +32,16 @@ class RoutineRepositoryTest {
     fun givenDayOfWeek_whenInsertAllRoutine_thenWorksFine() {
         runBlocking {
             // given
+            val insertDataList : List<RepeatRoutineEntity> = listOf()
             val dayOfWeek = "월"
-            whenever(localDateSource.getRepeatRoutines()).thenReturn(listOf())
+            whenever(localDateSource.getRepeatRoutines()).thenReturn(insertDataList)
             whenever(localDateSource.insertRoutines(listOf())).thenReturn(listOf())
 
             // when
-            sut.insertRoutinesFromRepeatRoutineByDayOfWeek(dayOfWeek)
+            val insertRowIds = sut.insertRoutinesFromRepeatRoutineByDayOfWeek(dayOfWeek)
 
             // then
+            assertThat(insertRowIds.size).isEqualTo(insertRowIds.size)
             verify(localDateSource).getRepeatRoutines()
             verify(localDateSource).insertRoutines(listOf())
         }
@@ -48,13 +51,15 @@ class RoutineRepositoryTest {
     fun givenRoutines_whenInsertAll_thenWorksFine() {
         runBlocking {
             // given
-            val routines = createRoutines(5, date)
+            val size = 5
+            val routines = createRoutines(size, date)
             whenever(localDateSource.insertRoutines(routines.toRoutineEntity())).thenReturn(listOf(1,2,3,4,5))
 
             // when
-            sut.insertRoutines(routines)
+            val insertRowIds = sut.insertRoutines(routines)
 
             // then
+            assertThat(insertRowIds.size).isEqualTo(routines.size)
             verify(localDateSource).insertRoutines(routines.toRoutineEntity())
 
         }
@@ -131,12 +136,14 @@ class RoutineRepositoryTest {
     fun givenDate_whenDeleteRoutines_thenWorksFine() {
         runBlocking {
             // given
-            whenever(localDateSource.deleteRoutinesByDate(date)).thenReturn(3)
+            val count = 3
+            whenever(localDateSource.deleteRoutinesByDate(date)).thenReturn(count)
 
             // when
-            sut.deleteRoutinesByDate(date)
+            val deleteCount = sut.deleteRoutinesByDate(date)
 
             // then
+            assertThat(deleteCount).isEqualTo(count)
             verify(localDateSource).deleteRoutinesByDate(date)
         }
     }
@@ -149,9 +156,10 @@ class RoutineRepositoryTest {
             whenever(localDateSource.deleteRoutine(routineId)).thenReturn(1)
 
             // when
-            sut.deleteRoutine(routineId)
+            val deleteCount = sut.deleteRoutine(routineId)
 
             // then
+            assertThat(deleteCount).isEqualTo(listOf(routineId).size)
             verify(localDateSource).deleteRoutine(routineId)
         }
     }

--- a/core/domain/src/main/java/com/example/domain/repository/CategoryRepository.kt
+++ b/core/domain/src/main/java/com/example/domain/repository/CategoryRepository.kt
@@ -7,8 +7,8 @@ interface CategoryRepository {
 
     suspend fun insertCategory(category: Category)
 
-    fun getAllCategoryListByFlow() : Flow<List<Category>>
+    fun getCategoriesFlow() : Flow<List<Category>>
 
-    suspend fun deleteCategory(category : Category)
+    suspend fun deleteCategory(category : Category) : Int
 
 }

--- a/core/domain/src/main/java/com/example/domain/repository/DateRepository.kt
+++ b/core/domain/src/main/java/com/example/domain/repository/DateRepository.kt
@@ -6,6 +6,6 @@ interface DateRepository {
 
     suspend fun insertDate(date : Int)
 
-    suspend fun getAllDateList() : List<Date>
+    suspend fun getDateList() : List<Date>
 
 }

--- a/core/domain/src/main/java/com/example/domain/repository/RepeatRoutineRepository.kt
+++ b/core/domain/src/main/java/com/example/domain/repository/RepeatRoutineRepository.kt
@@ -7,9 +7,9 @@ interface RepeatRoutineRepository {
 
     suspend fun insertRepeatRoutine(repeatRoutine: RepeatRoutine)
 
-    fun getAllRepeatRoutineListByFlow(): Flow<List<RepeatRoutine>>
+    fun getRepeatRoutinesFlow(): Flow<List<RepeatRoutine>>
 
-    suspend fun getAllRepeatRoutineList(): List<RepeatRoutine>
+    suspend fun getRepeatRoutines(): List<RepeatRoutine>
 
-    suspend fun deleteRepeatRoutine(text: String)
+    suspend fun deleteRepeatRoutine(text: String) : Int
 }

--- a/core/domain/src/main/java/com/example/domain/repository/ReviewRepository.kt
+++ b/core/domain/src/main/java/com/example/domain/repository/ReviewRepository.kt
@@ -8,6 +8,6 @@ interface ReviewRepository {
 
     suspend fun insertReview(review : Review)
 
-    suspend fun deleteReview(review: Review)
+    suspend fun deleteReview(review: Review) : Int
 
 }

--- a/core/domain/src/main/java/com/example/domain/repository/RoutineRepository.kt
+++ b/core/domain/src/main/java/com/example/domain/repository/RoutineRepository.kt
@@ -5,19 +5,19 @@ import kotlinx.coroutines.flow.Flow
 
 interface RoutineRepository {
 
-    suspend fun insertAllDailyRoutineFromRepeatRoutine(dayOfWeek : String)
+    suspend fun insertRoutinesFromRepeatRoutineByDayOfWeek(dayOfWeek : String)
 
-    suspend fun insertAllRoutine(routineList: List<Routine>)
+    suspend fun insertRoutines(routineList: List<Routine>)
 
     suspend fun insertRoutine(routine: Routine)
 
-    fun getAllDailyRoutineByFlow(date : Int) : Flow<List<Routine>>
+    fun getRoutinesFlowByDate(date : Int) : Flow<List<Routine>>
 
-    suspend fun getRoutineListByDate(date :Int) : List<Routine>
+    suspend fun getRoutinesByDate(date :Int) : List<Routine>
 
     suspend fun updateRoutine(routine : Routine)
 
-    suspend fun deleteAllRoutineByDate(date : Int)
+    suspend fun deleteRoutinesByDate(date : Int)
 
     suspend fun deleteRoutine(id : Int)
 

--- a/core/domain/src/main/java/com/example/domain/repository/RoutineRepository.kt
+++ b/core/domain/src/main/java/com/example/domain/repository/RoutineRepository.kt
@@ -5,9 +5,9 @@ import kotlinx.coroutines.flow.Flow
 
 interface RoutineRepository {
 
-    suspend fun insertRoutinesFromRepeatRoutineByDayOfWeek(dayOfWeek : String)
+    suspend fun insertRoutinesFromRepeatRoutineByDayOfWeek(dayOfWeek : String) : List<Long>
 
-    suspend fun insertRoutines(routineList: List<Routine>)
+    suspend fun insertRoutines(routineList: List<Routine>) : List<Long>
 
     suspend fun insertRoutine(routine: Routine)
 
@@ -17,8 +17,8 @@ interface RoutineRepository {
 
     suspend fun updateRoutine(routine : Routine)
 
-    suspend fun deleteRoutinesByDate(date : Int)
+    suspend fun deleteRoutinesByDate(date : Int) : Int
 
-    suspend fun deleteRoutine(id : Int)
+    suspend fun deleteRoutine(id : Int) : Int
 
 }

--- a/core/domain/src/main/java/com/example/domain/usecase/category/GetAllCategoryListByFlowUseCase.kt
+++ b/core/domain/src/main/java/com/example/domain/usecase/category/GetAllCategoryListByFlowUseCase.kt
@@ -8,6 +8,6 @@ import javax.inject.Inject
 class GetAllCategoryListByFlowUseCase @Inject constructor(private val repository: CategoryRepository) {
 
     operator fun invoke() : Flow<List<Category>> {
-        return repository.getAllCategoryListByFlow()
+        return repository.getCategoriesFlow()
     }
 }

--- a/core/domain/src/main/java/com/example/domain/usecase/date/GetAllDateListUseCase.kt
+++ b/core/domain/src/main/java/com/example/domain/usecase/date/GetAllDateListUseCase.kt
@@ -8,6 +8,6 @@ import javax.inject.Inject
 class GetAllDateListUseCase @Inject constructor(private val repository: DateRepository) {
 
     suspend operator fun invoke() : List<Date> {
-        return repository.getAllDateList()
+        return repository.getDateList()
     }
 }

--- a/core/domain/src/main/java/com/example/domain/usecase/repeatRoutine/GetAllRepeatRoutineListByFlowUseCase.kt
+++ b/core/domain/src/main/java/com/example/domain/usecase/repeatRoutine/GetAllRepeatRoutineListByFlowUseCase.kt
@@ -8,6 +8,6 @@ import javax.inject.Inject
 class GetAllRepeatRoutineListByFlowUseCase @Inject constructor(private val repository: RepeatRoutineRepository) {
 
     operator fun invoke(): Flow<List<RepeatRoutine>> {
-        return repository.getAllRepeatRoutineListByFlow()
+        return repository.getRepeatRoutinesFlow()
     }
 }

--- a/core/domain/src/main/java/com/example/domain/usecase/repeatRoutine/GetAllRepeatRoutineListUseCase.kt
+++ b/core/domain/src/main/java/com/example/domain/usecase/repeatRoutine/GetAllRepeatRoutineListUseCase.kt
@@ -7,6 +7,6 @@ import javax.inject.Inject
 class GetAllRepeatRoutineListUseCase @Inject constructor(private val repository: RepeatRoutineRepository) {
 
     suspend operator fun invoke() : List<RepeatRoutine>{
-        return repository.getAllRepeatRoutineList()
+        return repository.getRepeatRoutines()
     }
 }

--- a/core/domain/src/main/java/com/example/domain/usecase/routine/DeleteAllRoutineByDateUseCase.kt
+++ b/core/domain/src/main/java/com/example/domain/usecase/routine/DeleteAllRoutineByDateUseCase.kt
@@ -6,6 +6,6 @@ import javax.inject.Inject
 class DeleteAllRoutineByDateUseCase @Inject constructor(private val repository: RoutineRepository) {
 
     suspend operator fun invoke(date : Int){
-        repository.deleteAllRoutineByDate(date)
+        repository.deleteRoutinesByDate(date)
     }
 }

--- a/core/domain/src/main/java/com/example/domain/usecase/routine/GetAllDailyRoutineByFlowUseCase.kt
+++ b/core/domain/src/main/java/com/example/domain/usecase/routine/GetAllDailyRoutineByFlowUseCase.kt
@@ -8,6 +8,6 @@ import javax.inject.Inject
 class GetAllDailyRoutineByFlowUseCase @Inject constructor(private val repository: RoutineRepository) {
 
     operator fun invoke(date : Int) : Flow<List<Routine>> {
-        return repository.getAllDailyRoutineByFlow(date)
+        return repository.getRoutinesFlowByDate(date)
     }
 }

--- a/core/domain/src/main/java/com/example/domain/usecase/routine/GetRoutineListByDateUseCase.kt
+++ b/core/domain/src/main/java/com/example/domain/usecase/routine/GetRoutineListByDateUseCase.kt
@@ -7,6 +7,6 @@ import javax.inject.Inject
 class GetRoutineListByDateUseCase @Inject constructor(private val repository: RoutineRepository) {
 
     suspend operator fun invoke(date :Int) : List<Routine>{
-        return repository.getRoutineListByDate(date)
+        return repository.getRoutinesByDate(date)
     }
 }

--- a/core/domain/src/main/java/com/example/domain/usecase/routine/InsertAllDailyRoutineFromRepeatRoutineUseCase.kt
+++ b/core/domain/src/main/java/com/example/domain/usecase/routine/InsertAllDailyRoutineFromRepeatRoutineUseCase.kt
@@ -5,6 +5,6 @@ import javax.inject.Inject
 
 class InsertAllDailyRoutineFromRepeatRoutineUseCase @Inject constructor(private val repository: RoutineRepository) {
     suspend operator fun invoke(dayOfWeek: String) {
-        repository.insertAllDailyRoutineFromRepeatRoutine(dayOfWeek)
+        repository.insertRoutinesFromRepeatRoutineByDayOfWeek(dayOfWeek)
     }
 }


### PR DESCRIPTION
#74 해당 이슈에서 수정한것처럼 
여러개의 데이터를 조회하는 경우 컬렉션이름은 빼고 도메인의 복수형을 사용
delete 로직의 경우 삭제된 엔티티의 갯수를 반환함

Date의 경우 복수형이 존재하지 않기때문에 
DateList를 붙여줌


This closes #78 