### PR TITLE
기록화면에서 오늘에 해당하는 기록이 보이는 문제 수정

### DIFF
--- a/feature/record/src/main/java/com/hegunhee/record/screen/RecordViewModel.kt
+++ b/feature/record/src/main/java/com/hegunhee/record/screen/RecordViewModel.kt
@@ -7,6 +7,7 @@ import com.example.domain.usecase.review.DeleteReviewUseCase
 import com.example.domain.usecase.review.GetReviewOrNullByDateUseCase
 import com.example.domain.usecase.review.InsertReviewUseCase
 import com.example.domain.usecase.routine.GetRoutinesByDateUseCase
+import com.hegunhee.routiner.util.getTodayDate
 import dagger.hilt.android.lifecycle.HiltViewModel
 import hegunhee.routiner.model.Date
 import hegunhee.routiner.model.Review
@@ -45,7 +46,7 @@ class RecordViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            val currentDateList = getDateListUseCase()
+            val currentDateList = getDateListUseCase().filter { it.date != getTodayDate() }
             _dateList.value = currentDateList.mapIndexed { index, date ->
                 if(index == currentDateList.size -1) date.copy(isSelected = true)
                 else date


### PR DESCRIPTION
ViewModel에서 필터링 처리해준다.
왜냐하면 추후에 getDateListUseCase는 다른화면에서도 쓰일 수 있으므로 함부로 필터링을 하면 안된다고 생각했다.

This closes #125 