### PR TITLE
 Fix : 앱 첫 진입시 날짜를 저장하지 못하고 앱이 죽음

### DIFF
--- a/feature/main/src/main/java/com/example/main/screen/MainViewModel.kt
+++ b/feature/main/src/main/java/com/example/main/screen/MainViewModel.kt
@@ -60,7 +60,7 @@ class MainViewModel @Inject constructor(
         val todayDate = getTodayDate()
         val currentDate = getCurrentDateUseCase()
         if (currentDate != todayDate) {
-            insertDateUseCase(currentDate)
+            insertDateUseCase(todayDate)
             setCurrentDateUseCase(todayDate)
             _uiState.value = InsertRepeatRoutine
         } else {


### PR DESCRIPTION
앱이 첫 실행시 기본값이 아닌 오늘의 날짜를 저장하도록 설정 

This closes #149 