### PR TITLE
암시적 인텐트 스키마하고 호스트 이름 변경

### DIFF
--- a/feature/main/src/main/AndroidManifest.xml
+++ b/feature/main/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="app" android:host="main"/>
+                <data android:scheme="routiner" android:host="main"/>
             </intent-filter>
         </activity>
     </application>

--- a/feature/setting/src/main/java/com/hegunhee/setting/alarm/AlarmReceiver.kt
+++ b/feature/setting/src/main/java/com/hegunhee/setting/alarm/AlarmReceiver.kt
@@ -47,7 +47,7 @@ class AlarmReceiver() : BroadcastReceiver() {
     }
 
     private fun sendDailyAlarmNotification(context : Context,text : String) {
-            val contentIntent = Intent(Intent.ACTION_VIEW, Uri.parse("app://main"))
+            val contentIntent = Intent(Intent.ACTION_VIEW, Uri.parse("routiner://main"))
             val contentPendingIntent = PendingIntent.getActivity(
                 context,
                 ALARM_NOTIFICATION_ID,


### PR DESCRIPTION
아무래도 앱을 조회하는데 스킴이 app인것보다는 routiner로 지정해줘서 루티너만의 고유한 스킴을 보유하는게 좋을것같음

앱의 고유한 스킴은 routiner고 경로에 따라서 host를 분리하도록 설정

This closes #153 