### PR TITLE
target34 설정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 android {
     namespace = "com.hegunhee.routiner"
     defaultConfig {
-        targetSdk = 33
+        targetSdk = 34
         applicationId = "com.hegunhee.routiner"
         versionCode = (7)
         versionName = "1.4.0"

--- a/feature/main/src/main/AndroidManifest.xml
+++ b/feature/main/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="app" android:host="main"/>
+                <data android:scheme="routiner" android:host="main"/>
             </intent-filter>
         </activity>
     </application>

--- a/feature/setting/src/main/java/com/hegunhee/setting/alarm/AlarmReceiver.kt
+++ b/feature/setting/src/main/java/com/hegunhee/setting/alarm/AlarmReceiver.kt
@@ -47,7 +47,7 @@ class AlarmReceiver() : BroadcastReceiver() {
     }
 
     private fun sendDailyAlarmNotification(context : Context,text : String) {
-            val contentIntent = Intent(Intent.ACTION_VIEW, Uri.parse("app://main"))
+            val contentIntent = Intent(Intent.ACTION_VIEW, Uri.parse("routiner://main"))
             val contentPendingIntent = PendingIntent.getActivity(
                 context,
                 ALARM_NOTIFICATION_ID,

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-android.suppressUnsupportedCompileSdk=33


### PR DESCRIPTION
구글 플레이스토어의 권고사항이라 34로 변경하였다

android.suppressUnsupportedCompileSdk=33
해당 설정은 현재 AGP가 34버전을 지원하므로 삭제했다

현재 따로 targetSdk를 33 -> 34로 변경할때 
대응해야되는것은 따로 없어서 바로 targetSdk를 올렸다

해당 사항들은 https://developer.android.com/about/versions/14/behavior-changes-14?hl=ko
해당 링크에서 확인했다

This closes #152 